### PR TITLE
Fix tooltip hidden on IE

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -5,6 +5,7 @@ $tooltip-background-opacity: 0.9 !default
 $tooltip-max-width: 24rem !default
 
 .tooltip
+  overflow: visible
   position: relative
   &:hover,
   &.is-tooltip-active


### PR DESCRIPTION
Add `overflow: visible` to `.tooltip`