### PR TITLE
#61 fix arrow positioning for colored tooltips 

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -80,7 +80,8 @@
 						border-color: transparent transparent transparent rgba($color, $tooltip-background-opacity)
 				&.has-tooltip-right
 					&::after
-						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent				&:before
+						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent
+				&:before
 					background-color: rgba($color, $tooltip-background-opacity)
 					color: $color-invert
 

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -80,13 +80,7 @@
 						border-color: transparent transparent transparent rgba($color, $tooltip-background-opacity)
 				&.has-tooltip-right
 					&::after
-						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent
-				&:not(.has-tooltip-bottom),
-				&:not(.has-tooltip-left),
-				&:not(.has-tooltip-right)
-					&::after
-						border-color: rgba($color, $tooltip-background-opacity) transparent transparent transparent
-				&:before
+						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent				&:before
 					background-color: rgba($color, $tooltip-background-opacity)
 					color: $color-invert
 


### PR DESCRIPTION
`&:not` properties were overriding proper arrow position, i'm not sure what were they doing, please correct me if i'm wrong. Visually this fixes the bug.