### PR TITLE
#61 fix arrow positioning for colored tooltips 

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -72,6 +72,11 @@
 			$color: nth($pair, 1)
 			$color-invert: nth($pair, 2)
 			&.has-tooltip-#{$name}
+				&:not(.has-tooltip-bottom),
+				&:not(.has-tooltip-left),
+				&:not(.has-tooltip-right)
+					&::after
+						border-color: rgba($color, $tooltip-background-opacity) transparent transparent transparent
 				&.has-tooltip-bottom
 					&::after
 						border-color: transparent transparent rgba($color, $tooltip-background-opacity) transparent

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -80,7 +80,8 @@
 						border-color: transparent transparent transparent rgba($color, $tooltip-background-opacity)
 				&.has-tooltip-right
 					&::after
-						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent				&:before
+						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent
+				&:before
 					background-color: rgba($color, $tooltip-background-opacity)
 					color: $color-invert
 

--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -80,13 +80,7 @@
 						border-color: transparent transparent transparent rgba($color, $tooltip-background-opacity)
 				&.has-tooltip-right
 					&::after
-						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent
-				&:not(.has-tooltip-bottom),
-				&:not(.has-tooltip-left),
-				&:not(.has-tooltip-right)
-					&::after
-						border-color: rgba($color, $tooltip-background-opacity) transparent transparent transparent
-				&:before
+						border-color: transparent rgba($color, $tooltip-background-opacity) transparent transparent				&:before
 					background-color: rgba($color, $tooltip-background-opacity)
 					color: $color-invert
 


### PR DESCRIPTION
`&:not` properties were overriding proper arrow position, moved them to the top to preserve cascade.