### PR TITLE
$tooltip-font-size !default is missing

### DIFF
--- a/src/sass/_variables.sass
+++ b/src/sass/_variables.sass
@@ -3,7 +3,7 @@ $tooltip-background-color: $grey-dark !default
 $tooltip-background-opacity: 0.9 !default
 $tooltip-color: $white !default
 $tooltip-font-family: $family-primary !default
-$tooltip-font-size: $size-7
+$tooltip-font-size: $size-7 !default
 $tooltip-max-width: 15rem !default
 $tooltip-padding: .5rem 1rem !default
 $tooltip-radius: $radius-small !default


### PR DESCRIPTION
`$tooltip-font-size` couldn't be changed because the `!default` was missing.